### PR TITLE
feature: allow students to access grades in both "all-courses" and "expanded" view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Dummy repo
 This repository is a blank repository where students can try different practices on GitHub.
+
+Students are able to view their grades both in an "all-courses" view by visiting student_expanded.html.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Dummy repo
 This repository is a blank repository where students can try different practices on GitHub.
 
-Students are able to view their grades both in an "all-courses" view by visiting student_expanded.html.
+Students are able to view their grades both in an "all-courses" view by visiting student_allgrades.html.
+Students are able to view the scores for individual assignments within a specific course by visiting student_expanded.html.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Dummy repo
 This repository is a blank repository where students can try different practices on GitHub.
 
-Students are able to view their grades both in an "all-courses" view by visiting student_allgrades.html.
+Students are able to view their grades both in an "all-courses" view by visiting student_allcourses.html.
 Students are able to view the scores for individual assignments within a specific course by visiting student_expanded.html.

--- a/student_allcourses.html
+++ b/student_allcourses.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Grades: All Courses</title>
+    </head>
+    <body>
+
+    </body>
+</html>

--- a/student_allgrades.html
+++ b/student_allgrades.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Grades: Expanded</title>
+        <title>Grades: All Courses</title>
     </head>
     <body>
 

--- a/student_expanded.html
+++ b/student_expanded.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Grades: All Courses</title>
+    </head>
+    <body>
+
+    </body>
+</html>


### PR DESCRIPTION
This is a pull request to add the foundation for adding a feature so students can view grades from their currently enrolled courses. Two html files are added, but the feature has not yet been coded.

Changes:
Commit 130a9b3: 
1. Created student_expanded.html (This was ultimately a mistake)
2. Added a line to README.md reflecting the purpose of student_expanded.html.

Commit e306bb8: 
1. Created student_allgrades.html
2. Copied code from student_expanded.html to student_allgrades.html (Rectifying mistake from commit 130a9b3
3. Added a line to README.md reflecting the purpose of student_allgrades.html and altered the line in README.md reflecting the purpose of student_expanded.html